### PR TITLE
Use region variable for application arn

### DIFF
--- a/amzn-q-auth-tvm/lib/custom-oidc-stack.js
+++ b/amzn-q-auth-tvm/lib/custom-oidc-stack.js
@@ -242,7 +242,7 @@ class TVMOidcIssuerStack extends Stack {
             'qbusiness:PutFeedback',
             'qbusiness:DeleteConversation'
           ],
-          resources: [`arn:aws:qbusiness:us-east-1:${this.account}:application/*`]
+          resources: [`arn:aws:qbusiness:${this.region}:${this.account}:application/*`]
         }),
         new iam.PolicyStatement({
           sid: 'QBusinessSetContextPermissions',


### PR DESCRIPTION
*Issue #, if available:*
Region for application arn was hardcoded as `us-east-1`

*Description of changes:*
Fixing the application arn to use region variable instead of `us-east-1`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
